### PR TITLE
fix: stop searching a configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tfprovidercheck
 
+[Install](#install) | [Usage](#usage) | [Config](#configuration)
+
 Censor [Terraform Providers](https://developer.hashicorp.com/terraform/language/providers).
 
 ```console
@@ -72,10 +74,10 @@ Options:
 
 There are several ways to configure tfprovidercheck.
 
-1. The command line option `-config [-c]`
-1. The environment variable `TFPROVIDERCHECK_CONFIG_BODY`
-1. The environment variable `TFPROVIDERCHECK_CONFIG`
-1. tfprovidercheck looks for a configuration file `.tfprovidercheck.yaml` from the current directory to the root directory
+1. The command line option `-config [-c]`, which is the configuration file path
+1. The environment variable `TFPROVIDERCHECK_CONFIG_BODY`, which is the configuration itself (YAML)
+1. The environment variable `TFPROVIDERCHECK_CONFIG`, which is the configuration file path
+1. The configuration file `.tfprovidercheck.yaml` on the current directory
 
 The field `providers` lists allowed providers and their versions.
 
@@ -113,6 +115,10 @@ e.g.
 ```
 
 Then you can prevent configuration from being tampered by `pull_request_target` event.
+
+## Versioning Policy
+
+https://github.com/suzuki-shunsuke/versioning-policy
 
 ## LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/afero v1.10.0
-	github.com/suzuki-shunsuke/go-findconfig v1.2.0
 	github.com/suzuki-shunsuke/logrus-error v0.1.4
 	github.com/urfave/cli/v2 v2.25.7
 	golang.org/x/term v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/suzuki-shunsuke/go-findconfig v1.2.0 h1:PWHIyKZEsVmZVh6+K+rHVw0/XjTFmQEYfa8ZIzIJd0c=
-github.com/suzuki-shunsuke/go-findconfig v1.2.0/go.mod h1:lXzJUZQXrgsMmpHxXMVrWUAQpE4EopgDEJbwslvKbzs=
 github.com/suzuki-shunsuke/logrus-error v0.1.4 h1:nWo98uba1fANHdZ9Y5pJ2RKs/PpVjrLzRp5m+mRb9KE=
 github.com/suzuki-shunsuke/logrus-error v0.1.4/go.mod h1:WsVvvw6SKSt08/fB2qbnsKIMJA4K1MYCUprqsBJbMiM=
 github.com/urfave/cli/v2 v2.25.7 h1:VAzn5oq403l5pHjc4OhD54+XGO9cdKVL/7lDjF+iKUs=

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -3,8 +3,6 @@ package controller
 import (
 	"fmt"
 
-	"github.com/spf13/afero"
-	"github.com/suzuki-shunsuke/go-findconfig/findconfig"
 	"gopkg.in/yaml.v3"
 )
 
@@ -19,20 +17,11 @@ func (c *Controller) readConfig(cfg *Config, param *ParamRun) error {
 		}
 		return nil
 	}
-	if param.ConfigFilePath != "" {
-		return c.readConfigFile(cfg, param.ConfigFilePath)
+	if param.ConfigFilePath == "" {
+		// Don't search a configuration file from the current directory to the root directory to prevent being replaced with a fake configuration file
+		param.ConfigFilePath = ".tfprovidercheck.yaml"
 	}
-	cfgFilePath := findconfig.Find(param.PWD, func(p string) bool {
-		f, err := afero.Exists(c.fs, p)
-		if err != nil {
-			return false
-		}
-		return f
-	}, ".tfprovidercheck.yaml")
-	if cfgFilePath == "" {
-		return ErrConfigNotFound
-	}
-	return c.readConfigFile(cfg, cfgFilePath)
+	return c.readConfigFile(cfg, param.ConfigFilePath)
 }
 
 func (c *Controller) readConfigFile(cfg *Config, cfgFilePath string) error {

--- a/pkg/controller/run_test.go
+++ b/pkg/controller/run_test.go
@@ -54,7 +54,7 @@ func TestController_Run(t *testing.T) { //nolint:gocognit,cyclop,funlen
 		{
 			name:   "config isn't found",
 			param:  &controller.ParamRun{},
-			errMsg: `configuration file .tfprovidercheck.yaml isn't found`,
+			errMsg: `open a configuration file: `,
 		},
 		{
 			name: "config path",
@@ -103,12 +103,12 @@ func TestController_Run(t *testing.T) { //nolint:gocognit,cyclop,funlen
 			errMsg: `open a configuration file: `,
 		},
 		{
-			name: "config search",
+			name: "config file on the current directory",
 			param: &controller.ParamRun{
-				PWD: "/workspace/foo",
+				PWD: "/workspace",
 			},
 			files: map[string]string{
-				"/workspace/.tfprovidercheck.yaml": `providers:
+				".tfprovidercheck.yaml": `providers:
 - name: registry.terraform.io/hashicorp/aws
 `,
 			},


### PR DESCRIPTION
Stop searching a configuration file from the current directory to the root directory to prevent being replaced with a fake configuration file.